### PR TITLE
Change the file root extract logic to allow folders to have dynamic part ...

### DIFF
--- a/lib/logstash/outputs/file.rb
+++ b/lib/logstash/outputs/file.rb
@@ -79,7 +79,7 @@ class LogStash::Outputs::File < LogStash::Outputs::Base
   def validate_path
     root_directory = @path.split(File::SEPARATOR).select { |item| !item.empty? }.shift
 
-    if (root_directory =~ /%\{[^}]+\}/) != nil
+    if (root_directory =~ FIELD_REF) != nil
       @logger.error("File: The starting part of the path should not be dynamic.", :path => @path)
       raise LogStash::ConfigurationError.new("The starting part of the path should not be dynamic.")
     end

--- a/lib/logstash/outputs/file.rb
+++ b/lib/logstash/outputs/file.rb
@@ -7,6 +7,7 @@ require "zlib"
 # This output will write events to files on disk. You can use fields
 # from the event as parts of the filename and/or path.
 class LogStash::Outputs::File < LogStash::Outputs::Base
+  FIELD_REF = /%\{[^}]+\}/
 
   config_name "file"
   milestone 2
@@ -126,7 +127,7 @@ class LogStash::Outputs::File < LogStash::Outputs::Base
 
   private
   def path_with_field_ref?
-    path =~ /%\{[^}]+\}/
+    path =~ FIELD_REF
   end
 
   def format_message(event)
@@ -138,8 +139,8 @@ class LogStash::Outputs::File < LogStash::Outputs::Base
   end
 
   def extract_file_root
-    extracted_path = File.expand_path(path.gsub(/%{.+/, ''))
-    Pathname.new(extracted_path).expand_path
+    parts = File.expand_path(path).split(File::SEPARATOR)
+    parts.take_while { |part| part !~ FIELD_REF }.join(File::SEPARATOR)
   end
 
   def teardown

--- a/spec/outputs/file_spec.rb
+++ b/spec/outputs/file_spec.rb
@@ -186,6 +186,23 @@ describe LogStash::Outputs::File do
           end
         end
 
+        it 'write the events to a file when some part of a folder or file is dynamic' do
+          t = Time.now
+          good_event = LogStash::Event.new("@timestamp" => t)
+
+          Stud::Temporary.directory do |path|
+            dynamic_path = "#{path}/failed_syslog-%{+YYYY-MM-dd}"
+            expected_path = "#{path}/failed_syslog-#{t.strftime("%Y-%m-%d")}"
+
+            config = { "path" => dynamic_path }
+            output = LogStash::Outputs::File.new(config)
+            output.register
+            output.receive(good_event)
+
+            expect(File.exist?(expected_path)).to eq(true)
+          end
+        end
+
         it 'write the event to the generated filename with multiple deep' do
           good_event = LogStash::Event.new
           good_event['error'] = '/inside/errors/42.txt'


### PR DESCRIPTION
The current logic used to extract the root folder fails if the folder or file contains a dynamic part.

fixes: #3