### PR TITLE
Initial support for codec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0
+ - Add support for codec, using **json_lines** as default codec to keep default behavior.
+   Ref: https://github.com/logstash-plugins/logstash-output-file/pull/9
+
 ## 2.1.0
  - Add create_if_deleted option to create a destination file in case it
    was deleted by another agent in the machine. In case of being false

--- a/logstash-output-file.gemspec
+++ b/logstash-output-file.gemspec
@@ -21,10 +21,9 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", ">= 2.0.0.beta2", "< 3.0.0"
-  s.add_runtime_dependency 'logstash-input-generator'
   s.add_runtime_dependency 'logstash-codec-json_lines'
   s.add_runtime_dependency 'logstash-codec-line'
 
   s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'logstash-input-generator'
 end
-

--- a/logstash-output-file.gemspec
+++ b/logstash-output-file.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", ">= 2.0.0.beta2", "< 3.0.0"
   s.add_runtime_dependency 'logstash-input-generator'
+  s.add_runtime_dependency 'logstash-codec-json_lines'
+  s.add_runtime_dependency 'logstash-codec-line'
 
   s.add_development_dependency 'logstash-devutils'
 end

--- a/logstash-output-file.gemspec
+++ b/logstash-output-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-file'
-  s.version         = '2.1.0'
+  s.version         = '2.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output will write events to files on disk"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Change the file output behaviour to be codec-aware and remains backward compatible.
* Default to json_lines 
* Fallback to line codec when message_format is specified