### PR TITLE
Fix behaviour when the destination file is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.0
+ - Add create_if_deleted option to create a destination file in case it
+   was deleted by another agent in the machine. In case of being false
+   the system will add the incomming messages to the failure file.
+
 ## 2.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895

--- a/logstash-output-file.gemspec
+++ b/logstash-output-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-file'
-  s.version         = '2.0.2'
+  s.version         = '2.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output will write events to files on disk"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION

### Context

As commented out in #20, if during the time LS is running the destination file is deleted by another agent in the machine, the plugin takes the event without any kind of feedback. This makes the plugin behaviour awkward and confusing, including data loss.

### Reason

This happen because the plugin caches the file objects without doing any maintenance in case the file got deleted.  There is a check for something similar at ```close_stale_files``` function, but this might not make it on time.

### Fix

Add a new variable (```create_if_deleted```) to control the behaviour and make the open function react to it. Also include an option to forward events to the failure file in case this new variable is set to false. This enhancements make feedback always there, either by adding the files again to the destination file or using the failure file, there is also logging added.

Fixes #20 
