### PR TITLE
set time to UTC in specs to avoid mismatch with different timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.1
+ - Fixed Time specs
+
 ## 2.2.0
  - Add support for codec, using **json_lines** as default codec to keep default behavior.
    Ref: https://github.com/logstash-plugins/logstash-output-file/pull/9
@@ -8,7 +11,7 @@
    the system will add the incomming messages to the failure file.
 
 ## 2.0.0
- - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+ - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
 

--- a/logstash-output-file.gemspec
+++ b/logstash-output-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-file'
-  s.version         = '2.2.0'
+  s.version         = '2.2.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output will write events to files on disk"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/file_spec.rb
+++ b/spec/outputs/file_spec.rb
@@ -241,7 +241,7 @@ describe LogStash::Outputs::File do
         end
 
         it 'write the events to a file when some part of a folder or file is dynamic' do
-          t = Time.now
+          t = Time.now.utc
           good_event = LogStash::Event.new("@timestamp" => t)
 
           Stud::Temporary.directory do |path|
@@ -259,7 +259,7 @@ describe LogStash::Outputs::File do
         end
 
         it 'write the events to the generated path containing multiples fieldref' do
-          t = Time.now
+          t = Time.now.utc
           good_event = LogStash::Event.new("error" => 42,
                                            "@timestamp" => t,
                                            "level" => "critical",


### PR DESCRIPTION
set time to UTC in specs to avoid mismatch with different timezone

relates to elastic/logstash#4264 and elastic/logstash#4191
