### PR TITLE
Fixed specs to not depend on pipeline ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 2.2.1
+ - Fixed specs to not depend on pipeline ordering
+
+## 2.2.1
  - Fixed Time specs
 
 ## 2.2.0
@@ -14,4 +17,3 @@
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
-

--- a/logstash-output-file.gemspec
+++ b/logstash-output-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-file'
-  s.version         = '2.2.1'
+  s.version         = '2.2.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output will write events to files on disk"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/file_spec.rb
+++ b/spec/outputs/file_spec.rb
@@ -32,8 +32,9 @@ describe LogStash::Outputs::File do
       line_num = 0
 
       # Now check all events for order and correctness.
-      tmp_file.each_line do |line|
-        event = LogStash::Event.new(LogStash::Json.load(line))
+      events = tmp_file.map {|line| LogStash::Event.new(LogStash::Json.load(line))}
+      sorted = events.sort_by {|e| e['sequence']}
+      sorted.each do |event|
         insist {event["message"]} == "hello world"
         insist {event["sequence"]} == line_num
         line_num += 1
@@ -66,8 +67,9 @@ describe LogStash::Outputs::File do
       agent do
         line_num = 0
         # Now check all events for order and correctness.
-        Zlib::GzipReader.open(tmp_file.path).each_line do |line|
-          event = LogStash::Event.new(LogStash::Json.load(line))
+        events = Zlib::GzipReader.open(tmp_file.path).map {|line| LogStash::Event.new(LogStash::Json.load(line)) }
+        sorted = events.sort_by {|e| e["sequence"]}
+        sorted.each do |event|
           insist {event["message"]} == "hello world"
           insist {event["sequence"]} == line_num
           line_num += 1


### PR DESCRIPTION
This fixes #25 