### PR TITLE
Rename Dir.exists? to Dir.exist? to fix deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.3
+  - Rename Dir.exists? to Dir.exist? to fix deprecation warning
+
 ## 2.2.1
  - Fixed specs to not depend on pipeline ordering
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,6 +3,7 @@ reports, or in general have helped logstash along its way.
 
 Contributors:
 * Colin Surprenant (colinsurprenant)
+* Ivan Babrou (bobrik)
 * John E. Vincent (lusis)
 * Jordan Sissel (jordansissel)
 * Kayla Green (MixMuffins)

--- a/lib/logstash/outputs/file.rb
+++ b/lib/logstash/outputs/file.rb
@@ -233,7 +233,7 @@ class LogStash::Outputs::File < LogStash::Outputs::Base
     @logger.info("Opening file", :path => path)
 
     dir = File.dirname(path)
-    if !Dir.exists?(dir)
+    if !Dir.exist?(dir)
       @logger.info("Creating directory", :directory => dir)
       FileUtils.mkdir_p(dir)
     end

--- a/logstash-output-file.gemspec
+++ b/logstash-output-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-file'
-  s.version         = '2.2.2'
+  s.version         = '2.2.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output will write events to files on disk"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
```
warning: Dir.exists? is a deprecated name, use Dir.exist? instead
```