### PR TITLE
fix syntax error in example

### DIFF
--- a/lib/logstash/outputs/file.rb
+++ b/lib/logstash/outputs/file.rb
@@ -13,7 +13,7 @@ require "zlib"
 # output {
 #  file {
 #    path => ...
-#    codec => { line { format => "custom format: %{message}"}}
+#    codec => line { format => "custom format: %{message}"}
 #  }
 # }
 class LogStash::Outputs::File < LogStash::Outputs::Base


### PR DESCRIPTION
logstash 2.2.2 generates a syntax error on this example:
Error: Expected one of #, => at line 4, column 20 (byte 54) after output {
 file {
   path => "foobar"
   codec => { line

Fixed by removing braces at codec line 16. During testing I used path => "foobar".