### PR TITLE
line { format..} example syntax incorrect.

### DIFF
--- a/lib/logstash/outputs/file.rb
+++ b/lib/logstash/outputs/file.rb
@@ -13,7 +13,7 @@ require "zlib"
 # output {
 #  file {
 #    path => ...
-#    codec => { line { format => "custom format: %{message}"}}
+#    codec => line { format => "custom format: %{message}"}
 #  }
 # }
 class LogStash::Outputs::File < LogStash::Outputs::Base


### PR DESCRIPTION
`codec => { line { format => "custom format: %{message}"}}` throws a config error.  Tested 2.3.2, 2.1.1, and 1.5.4.

It looks like someone ran into this as well, PR [Failed Jenkins/CLA] https://github.com/logstash-plugins/logstash-output-file/pull/38 @ph 