### PR TITLE
Allow to install latest on 2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,28 @@
+## 4.0.1
+ - restore: Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
+
 ## 4.0.0
-  - Make 'message_format' option obsolete
-  - Use new Logsash 2.4/5.0 APIs for working batchwise and with shared concurrency
+ - Make 'message_format' option obsolete
+ - Use new Logstash 2.4/5.0 APIs for working batchwise and with shared concurrency
 
 ## 3.0.2
-  - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
+ - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
 
 ## 3.0.1
-  - Republish all the gems under jruby.
+ - Republish all the gems under jruby.
+
 ## 3.0.0
-  - Update the plugin to the version 2.0 of the plugin api, this change is required for Logstash 5.0 compatibility. See https://github.com/elastic/logstash/issues/5141
-# 2.2.5
-  - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
-# 2.2.4
-  - New dependency requirements for logstash-core for the 5.0 release
+ - Update the plugin to the version 2.0 of the plugin api, this change is required for Logstash 5.0 compatibility. See https://github.com/elastic/logstash/issues/5141
+
+## 2.2.5
+ - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
+
+## 2.2.4
+ - New dependency requirements for logstash-core for the 5.0 release
+
 ## 2.2.3
-  - Rename Dir.exists? to Dir.exist? to fix deprecation warning
-  - Allow setting dir and file permissions
+ - Rename Dir.exists? to Dir.exist? to fix deprecation warning
+ - Allow setting dir and file permissions
 
 ## 2.2.1
  - Fixed specs to not depend on pipeline ordering

--- a/logstash-output-file.gemspec
+++ b/logstash-output-file.gemspec
@@ -1,7 +1,8 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-file'
-  s.version         = '4.0.0'
+  s.version         = '4.0.1'
+  s.platform        = 'java'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output will write events to files on disk"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,7 +21,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", ">= 2.0.0", "< 2.99"
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-codec-json_lines'
   s.add_runtime_dependency 'logstash-codec-line'
 


### PR DESCRIPTION
* Restore dep to logstash-core-plugin-api to >= 1.60 <= 2.99 
* Add platform = java
* CHANGELOG format
