### PR TITLE
New `write_behavior` setting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.1.0
+  - New `write_behavior` feature. Value can be "append" (default) or
+    "overwrite". If "append", events will be appended to the end of the file.
+    If "overwrite", the file will only contain the last event written.
+
 ## 4.0.1
   - Move one log message from info to debug to avoid noise
 

--- a/logstash-output-file.gemspec
+++ b/logstash-output-file.gemspec
@@ -25,5 +25,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-codec-line'
 
   s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'flores'
   s.add_development_dependency 'logstash-input-generator'
 end

--- a/logstash-output-file.gemspec
+++ b/logstash-output-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-file'
-  s.version         = '4.0.1'
+  s.version         = '4.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output will write events to files on disk"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This setting introduces a new behavior to allow each event to overwrite
the entire file.

The default behavior (append) is unchanged.

Fixes #24