### PR TITLE
Fix log format in opening file

### DIFF
--- a/lib/logstash/outputs/file.rb
+++ b/lib/logstash/outputs/file.rb
@@ -18,7 +18,7 @@ require "zlib"
 # }
 class LogStash::Outputs::File < LogStash::Outputs::Base
   concurrency :shared
-  
+
   FIELD_REF = /%\{[^}]+\}/
 
   config_name "file"
@@ -50,7 +50,7 @@ class LogStash::Outputs::File < LogStash::Outputs::Base
   # into this file and inside the defined path.
   config :filename_failure, :validate => :string, :default => '_filepath_failures'
 
-  # If the configured file is deleted, but an event is handled by the plugin, 
+  # If the configured file is deleted, but an event is handled by the plugin,
   # the plugin will recreate the file. Default => true
   config :create_if_deleted, :validate => :boolean, :default => true
 
@@ -74,7 +74,7 @@ class LogStash::Outputs::File < LogStash::Outputs::Base
 
     @files = {}
     @io_mutex = Mutex.new
-    
+
     @path = File.expand_path(path)
 
     validate_path
@@ -133,16 +133,16 @@ class LogStash::Outputs::File < LogStash::Outputs::Base
         chunks.each {|chunk| fd.write(chunk) }
         fd.flush
       end
-      
+
       close_stale_files
-    end   
+    end
   end # def receive
 
   public
   def close
     @io_mutex.synchronize do
       @logger.debug("Close: closing files")
-      
+
       @files.each do |path, fd|
         begin
           fd.close
@@ -170,8 +170,8 @@ class LogStash::Outputs::File < LogStash::Outputs::Base
       file_output_path = @failure_path
     end
     @logger.debug("File, writing event to file.", :filename => file_output_path)
-    
-    file_output_path    
+
+    file_output_path
   end
 
   private
@@ -209,7 +209,7 @@ class LogStash::Outputs::File < LogStash::Outputs::Base
       @logger.debug("Flushing file", :path => path, :fd => fd)
       fd.flush
     end
-    
+
     @last_flush_cycle = Time.now
   end
 
@@ -257,8 +257,8 @@ class LogStash::Outputs::File < LogStash::Outputs::Base
       end
     end
 
-    @logger.info("Opening file", :path => path)
-    
+    @logger.info("Opening file #{path}")
+
     dir = File.dirname(path)
     if !Dir.exist?(dir)
       @logger.info("Creating directory", :directory => dir)
@@ -268,7 +268,7 @@ class LogStash::Outputs::File < LogStash::Outputs::Base
         FileUtils.mkdir_p(dir)
       end
     end
-    
+
     # work around a bug opening fifos (bug JRUBY-6280)
     stat = File.stat(path) rescue nil
     if stat && stat.ftype == "fifo" && LogStash::Environment.jruby?


### PR DESCRIPTION
Change opening-file log format to  same format to "closed file" .
