### PR TITLE
move require of flores into spec file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.2.1
+  - Bugfix: Move require of flores into the spec file instead of main file.rb
+
 ## 4.2.0
   - New `write_behavior` feature. Value can be "append" (default) or
     "overwrite". If "append", events will be appended to the end of the file.

--- a/lib/logstash/outputs/file.rb
+++ b/lib/logstash/outputs/file.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 require "logstash/namespace"
 require "logstash/outputs/base"
-require "flores/random"
 require "logstash/errors"
 require "zlib"
 

--- a/logstash-output-file.gemspec
+++ b/logstash-output-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-file'
-  s.version         = '4.2.0'
+  s.version         = '4.2.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Writes events to files on disk"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/file_spec.rb
+++ b/spec/outputs/file_spec.rb
@@ -9,6 +9,7 @@ require "stud/temporary"
 require "tempfile"
 require "uri"
 require "fileutils"
+require "flores/random"
 
 describe LogStash::Outputs::File do
   describe "ship lots of events to a file" do


### PR DESCRIPTION
Since flores is a development dependency and used only during tests, requiring it in the file.rb makes the plugin unusable.