### PR TITLE
bump version to 4.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.2.2
+  - Add feature `write_behavior` to the documentation #58
+
 ## 4.2.1
   - Bugfix: Move require of flores into the spec file instead of main file.rb
 

--- a/logstash-output-file.gemspec
+++ b/logstash-output-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-file'
-  s.version         = '4.2.1'
+  s.version         = '4.2.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Writes events to files on disk"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
changelog computed with:
```
% git lg v4.2.1..
* 93b1c0d - (HEAD -> master, origin/master, origin/HEAD) add feature write_behavior to doc (9 weeks ago) <WOLfgang Schricker>
* a6e3342 - [skip ci] update license to 2018 (2 months ago) <Joao Duarte>
```