### PR TITLE
remove (missing function) jruby check when opening fifos

### DIFF
--- a/lib/logstash/outputs/file.rb
+++ b/lib/logstash/outputs/file.rb
@@ -276,7 +276,7 @@ class LogStash::Outputs::File < LogStash::Outputs::Base
 
     # work around a bug opening fifos (bug JRUBY-6280)
     stat = File.stat(path) rescue nil
-    if stat && stat.ftype == "fifo" && LogStash::Environment.jruby?
+    if stat && stat.ftype == "fifo"
       fd = java.io.FileWriter.new(java.io.File.new(path))
     else
       if @file_mode != -1


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
