### PR TITLE
bump to 4.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.2.6
+  - Removed JRuby check when using FIFOs [#75](https://github.com/logstash-plugins/logstash-output-file/pull/75)
+
 ## 4.2.5
   - Fix a bug introduced in v4.2.4 where events on low-volume pipelines could remain unflushed for long periods when `flush_interval` was non-zero [#70](https://github.com/logstash-plugins/logstash-output-file/pull/70)
 

--- a/logstash-output-file.gemspec
+++ b/logstash-output-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-file'
-  s.version         = '4.2.5'
+  s.version         = '4.2.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Writes events to files on disk"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
```
% git lg v4.2.5..
* c166fbc - (HEAD -> master, origin/master) [skip ci] Travis: update LOGSTASH_BRANCH from 6.[0..4] to 6.5 (5 weeks ago) <Rob Bavey>
* c4c564e - pin bundler version to < 2 (5 weeks ago) <Rob Bavey>
* 38ad57b - remove (missing function) jruby check when opening fifos (5 weeks ago) <Joey Makar>
```