### PR TITLE
made stale_cleanup_interval configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-## Unreleased
+## 4.3.0
+  - Made `stale_cleanup_interval` configurable [#84](https://github.com/logstash-plugins/logstash-output-file/pull/84)
   - CI: upgrade testing [#83](https://github.com/logstash-plugins/logstash-output-file/pull/83)
 
 ## 4.2.6

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -49,6 +49,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-flush_interval>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-gzip>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-path>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-stale_cleanup_interval>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-write_behavior>> |<<string,string>>|No
 |=======================================================================
 
@@ -132,6 +133,15 @@ E.g.: `path => "./test-%{+YYYY-MM-dd}.txt"` to create
 If you use an absolute path you cannot start with a dynamic string.
 E.g: `/%{myfield}/`, `/test-%{myfield}/` are not valid paths
 
+[id="plugins-{type}s-{plugin}-stale_cleanup_interval"]
+===== `stale_cleanup_interval`
+
+  * Value type is <<number,number>>
+  * Default value is `10`
+
+Defines the interval, in seconds, between the stale files cleanup runs.
+The stale files cleanup cycle closes inactive files (i.e files not written to since the last cycle).
+
 [id="plugins-{type}s-{plugin}-write_behavior"]
 ===== `write_behavior`
 
@@ -140,8 +150,8 @@ E.g: `/%{myfield}/`, `/test-%{myfield}/` are not valid paths
 
 If `append`, the file will be opened for appending and each new event will be written at the end of the file.
 If `overwrite`, the file will be truncated before writing and only the most recent event will appear in the file.
-
 [id="plugins-{type}s-{plugin}-common-options"]
+
 include::{include_path}/{type}.asciidoc[]
 
 :default_codec!:

--- a/lib/logstash/outputs/file.rb
+++ b/lib/logstash/outputs/file.rb
@@ -73,6 +73,11 @@ class LogStash::Outputs::File < LogStash::Outputs::Base
   # If `overwrite`, the file will be truncated before writing and only the most
   # recent event will appear in the file.
   config :write_behavior, :validate => [ "overwrite", "append" ], :default => "append"
+  
+  # How often should the stale files cleanup cycle run (in seconds). 
+  # The stale files cleanup cycle closes inactive files (i.e files not written to since the last cycle).
+  config :stale_cleanup_interval, :validate => :number, :default => 10
+
 
   default :codec, "json_lines"
 
@@ -99,7 +104,6 @@ class LogStash::Outputs::File < LogStash::Outputs::Base
     end
 
     @last_stale_cleanup_cycle = Time.now
-    @stale_cleanup_interval = 10
   end
 
   def multi_receive_encoded(events_and_encoded)

--- a/logstash-output-file.gemspec
+++ b/logstash-output-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-file'
-  s.version         = '4.2.6'
+  s.version         = '4.3.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Writes events to files on disk"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This PR makes `stale_cleanup_interval` configurable.
A file that is periodically written to may be closed and then reopened and written to again.

Example: a minute-based file.
```
filter {
    ruby {
        code => "
            event.set('[@metadata][system_time]', Time.now.utc.strftime('%Y%m%d_%H%M'))
        "
    }
}
output {
 file {
   path => /var/logstash/output/%{[@metadata][system_time]}.txt.gz
   codec => json_lines
   gzip => true
   id => "file_output_plugin"
 }

```

Also solves #59 .