### PR TITLE
Added Feature: File size base log rotation

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -50,6 +50,8 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-gzip>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-path>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-write_behavior>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-write_behavior>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-write_behavior>> |<<string,string>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all

--- a/lib/logstash/outputs/file.rb
+++ b/lib/logstash/outputs/file.rb
@@ -282,8 +282,6 @@ class LogStash::Outputs::File < LogStash::Outputs::Base
       @files.each do |path, fd|
         @logger.debug("Flushing file", :path => path, :fd => fd)
         fd.flush
-        fd.close
-        @files.delete(path)
       end
     end
   rescue => e

--- a/logstash-output-file.gemspec
+++ b/logstash-output-file.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-file'
-  s.version         = '4.2.6'
+  s.version         = '4.3.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Writes events to files on disk"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/file_spec.rb
+++ b/spec/outputs/file_spec.rb
@@ -11,7 +11,6 @@ require "tempfile"
 require "uri"
 require "fileutils"
 require "flores/random"
-require "insist"
 
 describe LogStash::Outputs::File do
   describe "ship lots of events to a file" do

--- a/spec/outputs/file_spec.rb
+++ b/spec/outputs/file_spec.rb
@@ -11,6 +11,7 @@ require "tempfile"
 require "uri"
 require "fileutils"
 require "flores/random"
+require "insist"
 
 describe LogStash::Outputs::File do
   describe "ship lots of events to a file" do


### PR DESCRIPTION
# File size based log rotation

## Motivation
In one of our Projects we need to implement log rotation to make sure the disk does not fill up. 
As it seems not easily possible to simply use `logrotate` for that purpouse without the risk loosing events I've implemented a `file size based` rotation directly in this plugin.

Feature already in discussion here: #57

## Configuration
Rotation is enabled by setting the parameter `file_rotation_size` to a value > 0 (Default: 0) and otional set the parameter `max_file_rotation` to a non negative value to limit the number of created log files.
`keep_file_extension` => `true`, will prepend the rotation index before the file extension of the output path. Creating files like `/path/to/logs/app.0.log` `/path/to/logs/app.1.log` `/path/to/logs/app.2.log` ... 

## Implementation notes
The current file size is only checked when rotation is enabled.
The cleanup/housekeeping deletes only the last created file when limit has been reached e.g does not scvann folder for further files that may be deleted.

## Tests
I added tests to validate the implementation, in a very similar way other features are tested

I'd be very happy to see this feature merged into upstream so that with future releases we do not need to ship our own version of the plugin anymore.
Please give me feedback if there is anything further i can do to get this PR accepted.

Thanks to you all for all the work on this great product.

Kind Regards,
Christian 
